### PR TITLE
Fix messageformat compiler bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "messageformat": "~0.1.5",
-    "glob": "~3.1.14",
-    "underscore": "~1.4.3",
-    "async": "~0.1.22"
+    "async": "~0.9.0",
+    "glob": "~4.0.6",
+    "messageformat": "=0.1.7",
+    "underscore": "~1.7.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-nodeunit": "~0.1.2"
+    "grunt": "~0.4.5",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "~0.4.1"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "underscore": "~1.7.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-nodeunit": "~0.4.1"
+    "grunt": "~0.4.0",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~0.1.1",
+    "grunt-contrib-nodeunit": "~0.1.2"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Hi, 

Locking the version number of messageformat to =0.1.7 fixes this grunt plugin's issue #4.

I've updated other dependencies to working versions as well. 

Kind regards,
